### PR TITLE
Fix CMake minimum version warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 if(APPLE)
   cmake_minimum_required(VERSION 3.17)
 else()
-  cmake_minimum_required(VERSION 3.7)
+  cmake_minimum_required(VERSION 3.7...3.31)
 endif()
 
 if(POLICY CMP0072)

--- a/cmake/cpu.cmake
+++ b/cmake/cpu.cmake
@@ -15,7 +15,7 @@ function(webp_check_compiler_flag WEBP_SIMD_FLAG ENABLE_SIMD)
     set(WEBP_HAVE_${WEBP_SIMD_FLAG} 0 PARENT_SCOPE)
     return()
   endif()
-  unset(WEBP_HAVE_FLAG_${WEBP_SIMD_FLAG} CACHE)
+  # unset(WEBP_HAVE_FLAG_${WEBP_SIMD_FLAG} CACHE)
   cmake_push_check_state()
   set(CMAKE_REQUIRED_INCLUDES ${CMAKE_CURRENT_SOURCE_DIR})
   check_c_source_compiles(

--- a/src/webp/config.h
+++ b/src/webp/config.h
@@ -1,0 +1,6 @@
+/*
+	Empty config file.
+	
+	wxWidgets' Xcode project always defines HAVE_CONFIG_H so
+	it expects this file to be here.
+*/


### PR DESCRIPTION
Don't check SIMD flags on every re-configure.

Add an empty config.h required for XCode build.